### PR TITLE
Fixes ClusterIssuer which is using the wrong secret ref

### DIFF
--- a/cluster/core/cert-manager/letsencrypt-production.yaml
+++ b/cluster/core/cert-manager/letsencrypt-production.yaml
@@ -13,6 +13,6 @@ spec:
     - dns01:
         cloudflare:
           email: "${SECRET_EMAIL}"
-          apiKeySecretRef:
+          apiTokenSecretRef:
             name: cloudflare-token
             key: cloudflare-token

--- a/cluster/core/cert-manager/letsencrypt-staging.yaml
+++ b/cluster/core/cert-manager/letsencrypt-staging.yaml
@@ -13,6 +13,6 @@ spec:
     - dns01:
         cloudflare:
           email: "${SECRET_EMAIL}"
-          apiKeySecretRef:
+          apiTokenSecretRef:
             name: cloudflare-token
             key: cloudflare-token


### PR DESCRIPTION
In this linked issue: https://github.com/cert-manager/cert-manager/issues/3021#issuecomment-2715595410 It is described that changing from `apiKeySecretRef` to `apiTokenSecretRef` for the cloudflare ClusterIssuer fixes the problem I am having with authentication.